### PR TITLE
fix(test): avoid t.Cleanup with gomock

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -14,7 +14,7 @@ func TestNew(tt *testing.T) {
 	t := check.T(tt)
 	t.Parallel()
 	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
+	defer ctrl.Finish()
 
 	mockRepo := app.NewMockRepo(ctrl)
 	cfg := app.Config{

--- a/internal/app/balance_test.go
+++ b/internal/app/balance_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestBalance(tt *testing.T) {
 	t := check.T(tt)
-	a, _ := testNew(t)
+	cleanup, a, _ := testNew(t)
+	defer cleanup()
 
 	t.TODO().NotPanic(func() { a.Balance(ctx) })
 }

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -27,10 +27,9 @@ var (
 	ctx = context.Background()
 )
 
-func testNew(t *check.C) (*app.App, *app.MockRepo) {
+func testNew(t *check.C) (func(), *app.App, *app.MockRepo) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
 
 	mockRepo := app.NewMockRepo(ctrl)
 	mockRepo.EXPECT().LoadStartTime().Return(&time.Time{}, nil)
@@ -39,7 +38,7 @@ func testNew(t *check.C) (*app.App, *app.MockRepo) {
 		Duration: 60 * def.TestSecond,
 	})
 	t.Must(t.Nil(err))
-	return a, mockRepo
+	return ctrl.Finish, a, mockRepo
 }
 
 func waitErr(t *check.C, errc <-chan error, wait time.Duration, wantErr error) {

--- a/internal/app/lifecycle_test.go
+++ b/internal/app/lifecycle_test.go
@@ -14,7 +14,8 @@ import (
 func TestWait(tt *testing.T) {
 	t := check.T(tt)
 	t.Parallel()
-	a, mockRepo := testNew(t)
+	cleanup, a, mockRepo := testNew(t)
+	defer cleanup()
 
 	{ // ctxShutdown before a.Start().
 		ctx, shutdown := context.WithCancel(ctx)

--- a/internal/srv/openapi/handlers_test.go
+++ b/internal/srv/openapi/handlers_test.go
@@ -15,7 +15,8 @@ import (
 func TestGetBalance(tt *testing.T) {
 	t := check.T(tt)
 	t.Parallel()
-	c, _, mockApp := testNewServer(t)
+	cleanup, c, _, mockApp := testNewServer(t)
+	defer cleanup()
 	params := op.NewGetBalanceParams()
 
 	mockApp.EXPECT().Balance(gomock.Any()).Return(nil, io.EOF)

--- a/internal/srv/openapi/init_test.go
+++ b/internal/srv/openapi/init_test.go
@@ -30,7 +30,7 @@ var (
 	apiError500 = openapi.APIError(500, "internal error")
 )
 
-func testNewServer(t *check.C) (c *client.HighLoadCup2020, url string, mockAppl *app.MockAppl) {
+func testNewServer(t *check.C) (cleanup func(), c *client.HighLoadCup2020, url string, mockAppl *app.MockAppl) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 
@@ -46,12 +46,12 @@ func testNewServer(t *check.C) (c *client.HighLoadCup2020, url string, mockAppl 
 	errc := make(chan error, 1)
 	go func() { errc <- server.Serve() }()
 
-	t.Cleanup(func() {
+	cleanup = func() {
 		t.Helper()
 		t.Nil(server.Shutdown(), "server.Shutdown")
 		t.Nil(<-errc, "server.Serve")
 		ctrl.Finish()
-	})
+	}
 
 	ln, err := server.HTTPListener()
 	t.Must(t.Nil(err, "server.HTTPListener"))
@@ -70,5 +70,5 @@ func testNewServer(t *check.C) (c *client.HighLoadCup2020, url string, mockAppl 
 	_, err = (&http.Client{}).Do(req)
 	t.Must(t.Nil(err, "connect to service"))
 
-	return c, url, mockAppl
+	return cleanup, c, url, mockAppl
 }

--- a/internal/srv/openapi/srv_test.go
+++ b/internal/srv/openapi/srv_test.go
@@ -15,7 +15,8 @@ import (
 func TestServeSwagger(tt *testing.T) {
 	t := check.T(tt)
 	t.Parallel()
-	_, tsURL, _ := testNewServer(t)
+	cleanup, _, tsURL, _ := testNewServer(t)
+	defer cleanup()
 	c := &http.Client{}
 	swaggerSpec, err := loads.Embedded(restapi.SwaggerJSON, restapi.FlatSwaggerJSON)
 	t.Nil(err)


### PR DESCRIPTION
https://github.com/golang/mock/issues/428